### PR TITLE
No looping path for repeat with at most one repeat

### DIFF
--- a/src/visualize.js
+++ b/src/visualize.js
@@ -311,27 +311,30 @@ var plotNode={
     var r=padding;//radius
     var rectW=ret.width+padding*2,rectH=ret.y+ret.height+padding-y;
     width=rectW; height+=padding;
-    var p={
-      type:'path',
-      path:['M',ret.x+padding,y,
-            'Q',x,y,x,y+r,
-            'V',y+rectH-r,
-            'Q',x,y+rectH,x+r,y+rectH,
-            'H',x+rectW-r,
-            'Q',x+rectW,y+rectH,x+rectW,y+rectH-r,
-            'V',y+r,
-            'Q',x+rectW,y,ret.x+ret.width+padding,y
-          ],
-      _translate:_curveTranslate,
-      stroke:'maroon',
-      'stroke-width':2
-    };
-    if (repeat.nonGreedy) {
-      txt+="(NonGreedy!)";
-      p.stroke="Brown";
-      p['stroke-dasharray']="-";
+    var p;
+    if (repeat.max > 1) {
+        p={
+          type:'path',
+          path:['M',ret.x+padding,y,
+                'Q',x,y,x,y+r,
+                'V',y+rectH-r,
+                'Q',x,y+rectH,x+r,y+rectH,
+                'H',x+rectW-r,
+                'Q',x+rectW,y+rectH,x+rectW,y+rectH-r,
+                'V',y+r,
+                'Q',x+rectW,y,ret.x+ret.width+padding,y
+              ],
+          _translate:_curveTranslate,
+          stroke:'maroon',
+          'stroke-width':2
+        };
+        if (repeat.nonGreedy) {
+          txt+="(NonGreedy!)";
+          p.stroke="Brown";
+          p['stroke-dasharray']="-";
+        }
+        items.push(p);
     }
-    items.push(p);
     var skipPath;
     if (repeat.min===0) {//draw a skip path
       var skipRectH=y-ret.y+padding,skipRectW=rectW+padding*2;
@@ -352,7 +355,9 @@ var plotNode={
         stroke:'#333',
         'stroke-width':2
       };
-      translate([p],padding,0);
+      if (p) {
+        translate([p],padding,0);
+      }
       items.push(skipPath);
     }
 


### PR DESCRIPTION
Repeat used to display a looping path under the block regardless of the maximum number of times it can be used. When this maximum is one like with `c?` this looping path is actually useless.

![current](https://cloud.githubusercontent.com/assets/449671/5225329/6635c3ce-76e3-11e4-8133-6c128635fcb3.png)

Add a condition for the maximum and do not display the looping path is maximum is one. If minimum is 0, it already display a short circuit path on top of the block so both `{0, 1}` and `{1, 1}` will display properly.

![proposed](https://cloud.githubusercontent.com/assets/449671/5225331/6eaee968-76e3-11e4-9696-4b21d9350972.png)
